### PR TITLE
Us36 password reset

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -2,9 +2,17 @@
 
 namespace App\Controller;
 
+use App\Form\EmailFormType;
+use App\Repository\UserRepository;
+use App\Security\EmailVerifier;
+use Doctrine\ORM\EntityManager;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
@@ -32,5 +40,59 @@ class LoginController extends AbstractController
             'last_username' => $lastUsername,
             'error' => $error,
           ]);
+    }
+
+    /**
+     * @Route("/login/reset", name="reset_password")
+     */
+    public function askEmailForResetPassword(
+        Request $request,
+        UserRepository $userRepository,
+        MailerInterface $mailerInterface,
+        EmailVerifier $emailVerifier
+    ): Response {
+        $form = $this->createForm(EmailFormType::class);
+        $form->handleRequest($request);
+        //check if there's a form to handle and fetch the email
+        if ($form->isSubmitted() && $form->isValid()) {
+            $emailUser = $form->get('email')->getData();
+
+            //verify if there's a user registered with the email
+            $user = $userRepository->findOneBy(['email' => $emailUser]);
+            //if there's not user, notify the person
+            if ($user === null) {
+                $this->addFlash(
+                    'warning',
+                    "Aucun utilisateur n'est enregistré à cette adresse mail."
+                );
+                $this->redirectToRoute('reset_password');
+            } elseif ($user !== null && is_string($emailUser)) {
+                $emailVerifier->sendEmailConfirmation(
+                    'change_password',
+                    $user,
+                    (new TemplatedEmail())
+                    ->from(new Address('noreply@powy.io', 'Powy'))
+                    ->to($emailUser)
+                    ->subject('Mot de passe oublié')
+                    ->htmlTemplate('login/changePasswordEmail.html.twig')
+                );
+                $this->addFlash(
+                    'success',
+                    "Vous allez recevoir un mail à votre adresse afin de modifier votre mot de passe."
+                );
+                $this->redirectToRoute('login');
+            }
+        }
+        return $this->render('login/reset.html.twig', [
+            'EmailFormType' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * @Route("/login/password" ,name="change_password")
+     */
+    public function resetPassword(): Response
+    {
+        return $this->redirectToRoute('login');
     }
 }

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -155,7 +155,8 @@ class RegistrationController extends AbstractController
     public function verifyUserEmail(
         Request $request,
         UserRepository $userRepository,
-        MailerInterface $mailerInterface
+        MailerInterface $mailerInterface,
+        EntityManagerInterface $entityManager
     ): Response {
         // get id from the link clicked by the user to confirm his or her address
         $id = $request->get('id');
@@ -173,6 +174,9 @@ class RegistrationController extends AbstractController
         try {
             if ($user instanceof User) {
                 $this->emailVerifier->handleEmailConfirmation($request, $user);
+                $user->setIsVerified(true);
+                $entityManager->persist($user);
+                $entityManager->flush();
                 $this->addFlash('success', 'Votre adresse a bien été vérifiée.');
                 $emailUser = $user->getEmail();
                 if (is_string($emailUser)) {

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -27,7 +27,7 @@ class UserFixtures extends Fixture implements DependentFixtureInterface
             $student->setRoles(['ROLE_STUDENT']);
             $student->setFirstname('Alice' . $i);
             $student->setLastname('Martin' . $i);
-            $student->setGender('Female');
+            $student->setGender('female');
             $student->setAge('22');
             $student->setPhone('0234567890');
             $student->setIsVerified(true);
@@ -48,7 +48,7 @@ class UserFixtures extends Fixture implements DependentFixtureInterface
             $mentor->setRoles(['ROLE_MENTOR']);
             $mentor->setFirstname('Héloïse' . $i);
             $mentor->setLastname('Durand' . $i);
-            $mentor->setGender('Female');
+            $mentor->setGender('female');
             $mentor->setAge('42');
             $mentor->setPhone('0234567800');
             $mentor->setIsVerified(true);

--- a/src/Form/EditPasswordType.php
+++ b/src/Form/EditPasswordType.php
@@ -10,6 +10,7 @@ use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Validator\Constraints\Regex;
 
 class EditPasswordType extends AbstractType
 {
@@ -32,6 +33,11 @@ class EditPasswordType extends AbstractType
                         // max length allowed by Symfony for security reasons
                         'max' => 4096,
                     ]),
+                    new Regex([
+                        'pattern' => '/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d](?=.*?([^\w\s]|[_])).{8,}$/',
+                        'message' =>
+                        "Votre mot de passe doit contenir au moins un chiffre, une majuscule et un caractère spécial.",
+                    ])
                 ],
                 'label' => 'Nouveau mot de passe',
             ],

--- a/src/Form/EditPasswordType.php
+++ b/src/Form/EditPasswordType.php
@@ -28,7 +28,7 @@ class EditPasswordType extends AbstractType
                         'message' => 'Merci de saisir un nouveau de mot de passe',
                     ]),
                     new Length([
-                        'min' => 6,
+                        'min' => 8,
                         'minMessage' => 'Votre mot de passe doit avoir au moins {{ limit }} caractères',
                         // max length allowed by Symfony for security reasons
                         'max' => 4096,

--- a/src/Form/EmailFormType.php
+++ b/src/Form/EmailFormType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class EmailFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email', EmailType::class)
+        ;
+    }
+}

--- a/src/Security/EmailVerifier.php
+++ b/src/Security/EmailVerifier.php
@@ -55,10 +55,5 @@ class EmailVerifier
     public function handleEmailConfirmation(Request $request, User $user): void
     {
         $this->verifyEmailHelper->validateEmailConfirmation($request->getUri(), $user->getId(), $user->getEmail());
-
-        $user->setIsVerified(true);
-
-        $this->entityManager->persist($user);
-        $this->entityManager->flush();
     }
 }

--- a/templates/login/changePasswordEmail.html.twig
+++ b/templates/login/changePasswordEmail.html.twig
@@ -1,0 +1,9 @@
+<div style="text-align: center; margin-top: 2rem;">
+    <h1>Mot de passe oublié</h1>
+
+    <p>Afin d'enregistrer un nouveau mot de passe je t'invite à cliquer sur le lien suivant :</p>
+    <a href="{{ signedUrl }}">Changer mon mot de passe</a>
+    <p><strong>Attention, ce lien expirera dans {{ expiresAtMessageKey|trans(expiresAtMessageData, 'VerifyEmailBundle') }}.</strong></p>
+    <br>
+    <a href="mailto:hello@powy.io">hello@powy.io</a>
+</div>

--- a/templates/login/changePasswordEmail.html.twig
+++ b/templates/login/changePasswordEmail.html.twig
@@ -1,7 +1,7 @@
 <div style="text-align: center; margin-top: 2rem;">
     <h1>Mot de passe oublié</h1>
 
-    <p>Afin d'enregistrer un nouveau mot de passe je t'invite à cliquer sur le lien suivant :</p>
+    <p>Afin d'enregistrer un nouveau mot de passe, je t'invite à cliquer sur le lien suivant :</p>
     <a href="{{ signedUrl }}">Changer mon mot de passe</a>
     <p><strong>Attention, ce lien expirera dans {{ expiresAtMessageKey|trans(expiresAtMessageData, 'VerifyEmailBundle') }}.</strong></p>
     <br>

--- a/templates/login/change_password.html.twig
+++ b/templates/login/change_password.html.twig
@@ -7,6 +7,7 @@
 {{ include('components/_header.html.twig') }}
 {{ include('components/_flashmessages.html.twig') }}
 {{ form_start(formpassword) }}
+    <p>Merci d'entrer un nouveau mot de passe contenant au moins 8 caractères, une majuscule, un chiffre et un caractère spécial.</p>
     {{ form_row(formpassword.plainPassword.first) }}
     {{ form_row(formpassword._token) }}
     {{ form_row(formpassword.plainPassword.second) }}

--- a/templates/login/change_password.html.twig
+++ b/templates/login/change_password.html.twig
@@ -1,0 +1,16 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Mot de passe oublié{% endblock %}
+
+{% block body %}
+
+{{ include('components/_header.html.twig') }}
+{{ include('components/_flashmessages.html.twig') }}
+{{ form_start(formpassword) }}
+    {{ form_row(formpassword.plainPassword.first) }}
+    {{ form_row(formpassword._token) }}
+    {{ form_row(formpassword.plainPassword.second) }}
+    <button type="submit" class="dark-submit-button">Modifier</button>
+{{ form_end(formpassword) }}
+
+{% endblock %}

--- a/templates/login/index.html.twig
+++ b/templates/login/index.html.twig
@@ -27,7 +27,7 @@
                 <button type="submit" class="btn login">Je me connecte</button>
             </div>
             <div class="forgot">
-                <a href="#"><p>Mot de passe oublié ?</p></a>
+                <a href="{{ path('reset_password') }}"><p>Mot de passe oublié ?</p></a>
             </div>
             <div class="not-account">
                 <a href="{{ path('home') }}"><p>Vous n'avez pas de compte</p></a>

--- a/templates/login/reset.html.twig
+++ b/templates/login/reset.html.twig
@@ -1,0 +1,16 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Mot de passe oublié{% endblock %}
+
+{% block body %}
+
+   {{ include('components/_header.html.twig') }}
+   {{ include('components/_flashmessages.html.twig') }}
+   {{ form_start(EmailFormType) }}
+   {{ form_errors(EmailFormType) }}
+   {{ form_row(EmailFormType.email, {
+       label: 'Quelle est ton adresse mail ?'
+   }) }}
+   <button type="submit" class="btn">Ok</button>
+{{ form_end(EmailFormType) }}
+{% endblock %}

--- a/templates/login/reset.html.twig
+++ b/templates/login/reset.html.twig
@@ -12,5 +12,5 @@
        label: 'Quelle est ton adresse mail ?'
    }) }}
    <button type="submit" class="btn">Ok</button>
-{{ form_end(EmailFormType) }}
+    {{ form_end(EmailFormType) }}
 {% endblock %}

--- a/templates/profile/password_changed.html.twig
+++ b/templates/profile/password_changed.html.twig
@@ -1,0 +1,7 @@
+<div style="text-align: center; margin-top: 2rem;">
+    <h1>Modifications enregistrées !</h1>
+    <p>Nous avons bien pris en compte ton nouveau mot de passe, {{ user.email }} !</p>
+    <p>Tu peux maintenant te connecter sur Powy afin d'utiliser les services du site.</p>
+    <br>
+    <a href="mailto:hello@powy.io">hello@powy.io</a>
+</div>


### PR DESCRIPTION
Added :
- methods in LoginController to reset password in 2 steps (first : send an email, second : change password)
- views with forms (one with only email for the first step, and second with editpasswordform to change only password)
- templates for mail (one with the link to let the user be redirected to the editpassword, second to confirm the changes)

Changed :
- regex on password in EditPassWordType

To do in another PR : add style to the views