### PR TITLE
fixed security on chat controller

### DIFF
--- a/src/Controller/ChatController.php
+++ b/src/Controller/ChatController.php
@@ -28,7 +28,13 @@ class ChatController extends AbstractController
     ): Response {
         //fetch Mentoring
         $mentoring = $mentoringManager->fetchMentoring($user);
-
+        // if user connected is not the user from the mentoring, redirect to his/her chat
+        if ($this->getUser() instanceof User) {
+            $idUserConnected = $this->getUser()->getId();
+            if ($user->getId() !== $idUserConnected) {
+                return $this->redirectToRoute('chat', ['id' => $idUserConnected]);
+            }
+        }
         //create message form
         $message = new Message();
         $form = $this->createForm(MessageType::class, $message);


### PR DESCRIPTION
There were a pb with security on the chat.
A user was able to change the id on the route and access to the form of another chat (not the messages) and send a message to the other chat.
now the chat controller check if the connected user is the same as the user id sent to the route and if not redirect to the correct chat.